### PR TITLE
getOffset() not returning numeric value

### DIFF
--- a/select.cfc
+++ b/select.cfc
@@ -8,7 +8,7 @@ component accessors="true" {
 	property name="where" type="string" default="";
 	property name="orderBy" type="string";
 	property name="rowcount" type="numeric";
-	property name="offset" type="numeric";
+	property name="offset" type="numeric" default="0";
 	property name="params" type="struct";
 	property name="cachedWithinMinutes" type="numeric";
 	property name="Datasource" type="string";


### PR DESCRIPTION
I am getting an error when attempting to use a limit:

```
        var q = new select('*')
            .from('Payments')
            .where('memberGUID = "#session.memberGUID#" AND active = 1 AND deleted = 0')
            .limit(10);
```

When the query is prepared it is errors on line 128. Since the offset has not been set the return type of getOffset() is not numeric, it is returning the select object. Defaulting the offset to 0 so getOffset always returns a numeric value seemed like the best option.
